### PR TITLE
move rmf-panel front end to rmf-panel-js repo

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -20,7 +20,9 @@ jobs:
           mkdir .public
           mv rmf_panel/dist .public/
           mv rmf_panel/index.html .public/
+      ## Will only deply page during merge to main
       - name: deploy_page
+        # if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -11,16 +11,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1
-
       - name: Install and Build
         run: |
           npm install  --prefix rmf_panel
           npm run build  --prefix rmf_panel
-      - name: trim
+      - name: Trim Dist
         run: |
           mkdir .public
-          mv -r rmf_panel/dist .public/
-          mv rmf_panel/index.html .public
+          mv rmf_panel/dist .public/
+          mv rmf_panel/index.html .public/
       - name: deploy_page
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -1,9 +1,9 @@
 
-name: github pages
+name: gh-page
 on:
   push:
-    branches: [ main, contruct-repo ] # TODO: remove test repo soon
-  pull_request: # Comment this out soon
+    branches: [ main ]
+  pull_request:
     branches: [ main ]
 jobs:
   build-and-deploy:
@@ -20,9 +20,9 @@ jobs:
           mkdir .public
           mv rmf_panel/dist .public/
           mv rmf_panel/index.html .public/
-      ## Will only deply page during merge to main
+      ## Will only deploy page during merge to main
       - name: deploy_page
-        # if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -1,0 +1,28 @@
+
+name: github pages
+on:
+  push:
+    branches: [ main, contruct-repo ] # TODO: remove test repo soon
+  pull_request: # Comment this out soon
+    branches: [ main ]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+
+      - name: Install and Build
+        run: |
+          npm install  --prefix rmf_panel
+          npm run build  --prefix rmf_panel
+      - name: trim
+        run: |
+          mkdir .public
+          mv -r rmf_panel/dist .public/
+          mv rmf_panel/index.html .public
+      - name: deploy_page
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .public

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+package-lock.json
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rmf-panel-js
 
+![](https://github.com/open-rmf/rmf-panel-js/workflows/gh-page/badge.svg)
+
 Front end rmf_demos_panel for [rmf demos](https://github.com/open-rmf/rmf_demos/)
 
 Open link here: https://open-rmf.github.io/rmf-panel-js/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # rmf-panel-js
-front end rmf_demos_panel for rmf demos
 
+Front end rmf_demos_panel for [rmf demos](https://github.com/open-rmf/rmf_demos/)
 
-## Build Instructions
+Open link here: https://open-rmf.github.io/rmf-panel-js/
+
+## Run local server
+
+### Build Instructions
 
 ```bash
 npm install --prefix rmf_panel
 npm run build --prefix rmf_panel
 ```
+
+### Run
+
+```bash
+cd rmf_panel
+python3 -m http.server 3000
+```
+Then open http://localhost:3000/ on browser

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# rmf_panel_js
+# rmf-panel-js
 front end rmf_demos_panel for rmf demos
+
+
+## Build Instructions
+
+```bash
+npm install --prefix rmf_panel
+npm run build --prefix rmf_panel
+```

--- a/rmf_panel/index.html
+++ b/rmf_panel/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/3.0.5/socket.io.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/antd/4.9.4/antd.min.css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+<head>
+  <title>RMF Panel</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<body>
+  <div id="root">
+    <p>Loading... dist/app.bundle.js.</p>
+    </p>
+  </div>
+<hr>
+
+<script src="dist/app.bundle.js" type="text/javascript"></script>
+</body>
+</html>

--- a/rmf_panel/jest.config.js
+++ b/rmf_panel/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  roots: ["<rootDir>/src"],
+  transform: { "^.+\\.(ts|tsx|js|jsx)?$": "ts-jest" },
+  setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"]
+};

--- a/rmf_panel/package.json
+++ b/rmf_panel/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "rmf_demos_panel",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "build": "webpack --progress --config webpack.config.js",
+    "build-dev": "webpack --mode development --progress --config webpack.config.js",
+    "dev-build": "webpack --progress --config webpack.config.js",
+    "watch": "webpack --progress --config webpack.config.js --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/osrf/rmf_demos.git"
+  },
+  "author": "OSRF",
+  "babel": {
+    "presets": [
+      "@babel/preset-env",
+      "@babel/preset-react"
+    ]
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/osrf/rmf_demos/issues"
+  },
+  "dependencies": {
+    "@material-ui/core": "^4.11.1",
+    "@material-ui/icons": "^4.11.2",
+    "antd": "^4.13.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "socket.io-client": "^3.0.4",
+    "typescript": "^4.1.2"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.9",
+    "@babel/preset-env": "^7.12.7",
+    "@babel/preset-react": "^7.12.7",
+    "@material-ui/lab": "^4.0.0-alpha.56",
+    "@testing-library/jest-dom": "^5.11.6",
+    "@testing-library/react": "^11.2.2",
+    "@testing-library/user-event": "^12.6.0",
+    "@types/jest": "^26.0.19",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "@types/socket.io-client": "^1.4.34",
+    "babel-jest": "^26.6.3",
+    "babel-loader": "^8.2.1",
+    "file-loader": "^6.2.0",
+    "jest": "^26.6.3",
+    "json-loader": "^0.5.7",
+    "ts-jest": "^26.4.4",
+    "ts-loader": "^8.0.11",
+    "webpack": "^5.10.0",
+    "webpack-cli": "^4.2.0"
+  }
+}

--- a/rmf_panel/setupTests.js
+++ b/rmf_panel/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/rmf_panel/src/__tests__/cleaning-form.test.tsx
+++ b/rmf_panel/src/__tests__/cleaning-form.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'; 
+import CleaningForm from '../components/forms/cleaning-form';
+
+describe('Cleaning Form', () => {
+    let root: ReturnType<typeof renderForm>;
+    let submitRequest = jest.fn();
+    let setTimeError = jest.fn();
+    let setMinsFromNow = jest.fn();
+    let setPriority = jest.fn();
+    let setPriorityError = jest.fn();
+    let minsFromNow = 0;
+    let priority = 0;
+    let timeAndPriority = { minsFromNow, priority, setTimeError, setMinsFromNow, setPriority, setPriorityError }
+
+    function renderForm() {
+        const cleaningZones = ['zone1', 'zone2'];
+        return render(<CleaningForm cleaningZones={cleaningZones} submitRequest={submitRequest} timeAndPriority={timeAndPriority} />);
+    }
+
+    beforeEach(() => {
+        root = renderForm();
+    });
+
+    afterEach(() => {
+        root.unmount();
+        cleanup();
+    });
+
+    it("should render", () => {
+        expect(screen.getByRole('cleaning-form')).toBeInTheDocument();
+    });
+
+    it("should render error messages when invalid form is submitted", () => {
+        const submitButton = screen.getByText('Submit Request');
+        fireEvent.click(submitButton);
+        expect(root.container.querySelector('.MuiFormHelperText-root.Mui-error')).toBeTruthy();
+        expect(screen.getByText("Cleaning zone cannot be an empty field")).toBeInTheDocument();
+    });
+
+    it("should submit a valid form", () => {
+        const submitButton = screen.getByText('Submit Request');
+        userEvent.click(root.getByLabelText('Pick a zone'));
+        userEvent.click(within(screen.getAllByRole('listbox')[0]).getByText('zone1'));
+        userEvent.click(submitButton);
+        expect(submitRequest).toHaveBeenCalled();
+    });
+});

--- a/rmf_panel/src/__tests__/delivery-form.test.tsx
+++ b/rmf_panel/src/__tests__/delivery-form.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { cleanup, render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DeliveryForm from '../components/forms/delivery-form';
+
+describe('Delivery Form', () => {
+    let root: ReturnType<typeof renderForm>;
+    let submitRequest = jest.fn();
+    let setTimeError = jest.fn();
+    let setMinsFromNow = jest.fn();
+    let setPriority = jest.fn();
+    let setPriorityError = jest.fn();
+    let minsFromNow = 0;
+    let priority = 0;
+    let timeAndPriority = { minsFromNow, priority, setTimeError, setMinsFromNow, setPriority, setPriorityError }
+    
+    function renderForm() {
+        const deliveryOptions = {
+            "mop": {
+              "pickup_place_name": "mopcart_pickup",
+              "pickup_dispenser": "mopcart_dispenser",
+              "dropoff_place_name": "spill",
+              "dropoff_ingestor": "mopcart_collector"
+            }
+        }
+        return render(<DeliveryForm deliveryOptions={deliveryOptions} submitRequest={submitRequest} timeAndPriority={timeAndPriority}/>);
+    }
+
+    beforeEach(() => {
+        root = renderForm();
+    });
+
+    afterEach(() => {
+        root.unmount();
+        cleanup();
+    });
+
+    it("should render", () => {
+        expect(screen.getByRole('delivery-form')).toBeInTheDocument();
+    });
+
+    it("should render error messages when invalid form is submitted", () => {
+        const submitButton = screen.getByText('Submit Request');
+        userEvent.click(submitButton);
+        expect(root.container.querySelector('.MuiFormHelperText-root.Mui-error')).toBeTruthy();
+    });
+
+    it("should submit a valid form", () => {
+        const submitButton = screen.getByText('Submit Request');
+        userEvent.click(root.getByLabelText('Select delivery task'));
+        userEvent.click(within(screen.getAllByRole('listbox')[0]).getByText('mop'));
+        userEvent.click(submitButton);
+        expect(submitRequest).toHaveBeenCalled();
+    });
+});

--- a/rmf_panel/src/__tests__/footer.test.tsx
+++ b/rmf_panel/src/__tests__/footer.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Footer from '../components/fixed-components/footer';
+
+describe('Footer', () => {
+    it("should render", () => {
+        render(<Footer />);
+        expect(screen.getByRole('footer')).toBeVisible();
+    
+    });
+})

--- a/rmf_panel/src/__tests__/header.test.tsx
+++ b/rmf_panel/src/__tests__/header.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Header from '../components/fixed-components/header';
+
+describe('Header', () => {
+    it("should render", () => {
+        render(<Header />);
+        expect(screen.getByRole('header')).toBeVisible();
+    
+    });
+})

--- a/rmf_panel/src/__tests__/loop-request-form.test.tsx
+++ b/rmf_panel/src/__tests__/loop-request-form.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { cleanup, render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoopRequestForm from '../components/forms/loop-request-form';
+
+describe('Loop Request Form', () => {
+    let root: ReturnType<typeof renderForm>;
+    let submitRequest = jest.fn();
+     let setTimeError = jest.fn();
+    let setMinsFromNow = jest.fn();
+    let setPriority = jest.fn();
+    let setPriorityError = jest.fn();
+    let minsFromNow = 0;
+    let priority = 0;
+    let timeAndPriority = { minsFromNow, priority, setTimeError, setMinsFromNow, setPriority, setPriorityError }
+    
+    function renderForm() {
+        const availablePlaces = ['place1', 'place2'];
+        return render(<LoopRequestForm availablePlaces={availablePlaces} submitRequest={submitRequest} timeAndPriority={timeAndPriority}/>);
+    }
+    
+    beforeEach(() => {
+        root = renderForm();
+    });
+
+    afterEach(() => {
+        root.unmount();
+        cleanup();
+    });
+    
+    it("should render", () => {
+        expect(screen.getByRole('loop-request-form')).toBeInTheDocument();
+    });
+
+    it("should render error messages when invalid form is submitted", () => {
+        const submitButton = screen.getByText('Submit Request');
+        fireEvent.click(submitButton);
+        expect(root.container.querySelector('.MuiFormHelperText-root.Mui-error')).toBeTruthy();
+    });
+
+    it("should submit a valid form", () => {
+        const submitButton = screen.getByText('Submit Request');
+        userEvent.click(root.getByLabelText('Select start location'));
+        userEvent.click(within(screen.getAllByRole('listbox')[0]).getByText('place1'));
+        userEvent.click(root.getByLabelText('Select end location'));
+        userEvent.click(within(screen.getAllByRole('listbox')[0]).getByText('place2'));
+        fireEvent.click(submitButton);
+        expect(submitRequest).toHaveBeenCalled();
+    });
+});

--- a/rmf_panel/src/__tests__/robot-card.test.tsx
+++ b/rmf_panel/src/__tests__/robot-card.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RobotCard } from '../components/robots/robot-card';
+
+describe('Robot Card', () => {
+    const exampleState  = {
+        robot_name: "magnus",
+        fleet_name: "fleet1",
+        assignments: ["1003", "task2", "Loop3"],
+        mode: "Idle-0",
+        battery_percent: "99.99998474121094",
+        level_name: "Level 2"
+    };
+
+    it("should render", () => {
+        const root = render(<RobotCard robotState={exampleState} />);
+        expect(screen.getByRole('robot-details')).toBeInTheDocument();
+        root.unmount();
+    });
+
+    it("should render arrows in assigned tasks", () => {
+        render(<RobotCard robotState={exampleState} />);
+        expect(screen.getByText('1003 ➜task2 ➜Loop3')).toBeInTheDocument();
+    });
+});

--- a/rmf_panel/src/__tests__/scheduled-task-form.test.tsx
+++ b/rmf_panel/src/__tests__/scheduled-task-form.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'; 
+import ScheduledTaskForm from '../components/forms/scheduled-task-form';
+
+describe('Scheduled Task Form', () => {
+    let root: ReturnType<typeof renderForm>;
+    const expectedTimeoutId = 42;
+    jest.useFakeTimers();
+    const submitRequest = (setTimeout as unknown as jest.Mock);
+    submitRequest.mockImplementation(() => expectedTimeoutId);
+
+    function renderForm() {
+        return render(<ScheduledTaskForm submitTaskList={submitRequest} />);
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        root = renderForm();
+    });
+
+    afterEach(() => {
+        root.unmount();
+        cleanup();
+    });
+
+    it("should render", () => {
+        expect(screen.getByRole('scheduled-task-form')).toBeInTheDocument();
+    });
+
+    it("should render error messages when empty form is submitted", () => {
+        const submitButton = screen.getByText('Submit Task List');
+        fireEvent.click(submitButton);
+        expect(root.getByText("Unable to submit an empty task list")).toBeTruthy();
+        expect(submitRequest).not.toHaveBeenCalled();
+    });
+
+    it("should show the file name and text content when a file is uploaded", async () => {
+        const tasks = new File([`[{"task_type":"Clean", "start_time":0, "priority": 0, "description": {"cleaning_zone":"zone_1"}}]`], 'tasks.json', {
+            type: 'json',
+        });
+        
+        const inputEl = root.getByLabelText('Select File');
+        Object.defineProperty(inputEl, 'files', {
+            value: [tasks],
+        });
+
+        await waitFor(() => {
+            fireEvent.change(inputEl);
+            expect(root.getByText('[{"task_type":"Clean", "start_time":0, "priority": 0, "description": {"cleaning_zone":"zone_1"}}]')).toBeTruthy();
+            expect(root.queryByLabelText('Select File')).toBeNull();
+            expect(root.getByLabelText('tasks.json')).toBeTruthy();
+        });
+    });
+
+    it("should submit a valid form", () => {
+        const tasks = `[ {"task_type":"Clean", "start_time": 0, "priority": 0, "description": {"cleaning_zone":"zone_1"}}, {"task_type":"Clean", "start_time": 10, "priority": 0, "description": {"cleaning_zone":"zone_2"}}, {"task_type":"Clean", "start_time": 5, "priority": 0, "description": {"cleaning_zone":"zone_3"}} ]`
+        const submitButton = screen.getByText('Submit Task List');
+        const taskListBox = root.getByPlaceholderText(/eg.*/);
+        userEvent.type(taskListBox, tasks);
+        fireEvent.click(submitButton);
+        expect(submitRequest).toHaveBeenCalled();
+    });
+
+    it("should render text content when the same file is uploaded again after first submission", async () => {
+        const list = `[{"task_type":"Clean", "start_time": 0, "priority": 0, "description": {"cleaning_zone":"zone_1"}}]`
+        const tasks = new File([list], 'tasks.json', {
+            type: 'json',
+        });
+        
+        const inputEl = root.getByLabelText('Select File');
+        Object.defineProperty(inputEl, 'files', {
+            value: [tasks],
+        });
+
+        await waitFor(() => {
+            fireEvent.change(inputEl);
+            expect(root.getByText(list)).toBeTruthy();
+            expect(root.queryByLabelText('Select File')).toBeNull();
+            expect(root.getByLabelText('tasks.json')).toBeTruthy();
+        });
+        const submitButton = root.getByText('Submit Task List');
+        fireEvent.click(submitButton);
+        expect(submitRequest).toHaveBeenCalled();
+
+        await waitFor(() => {
+            expect(root.queryByText(list)).toBeNull();
+        });
+
+        await waitFor(() => {
+            fireEvent.change(inputEl);
+            expect(root.getByText(list)).toBeTruthy();
+            expect(root.queryByLabelText('Select File')).toBeNull();
+            expect(root.getByLabelText('tasks.json')).toBeTruthy();
+        });
+    });
+});

--- a/rmf_panel/src/__tests__/tabs.test.tsx
+++ b/rmf_panel/src/__tests__/tabs.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NavTabs from '../components/fixed-components/tabs';
+
+describe('Nav Tabs', () => {
+    it("should render", () => {
+        render(<NavTabs worldName="testWorld" />);
+        expect(screen.getByRole('nav-tabs')).toBeVisible();
+    });
+});

--- a/rmf_panel/src/__tests__/task-card.test.tsx
+++ b/rmf_panel/src/__tests__/task-card.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TaskCard } from '../components/tasks/task-card';
+
+describe('Task Card', () => {
+    const exampleState  = {
+        task_id: "1003",
+        description: "zone_x",
+        robot_name: "magnus",
+        state: "Active/Executing",
+        task_type: "Clean",
+        priority: 1,
+        start_time: 1500,
+        end_time: 1540,
+        progress: "42"
+    };
+
+    const failedState  = {
+        task_id: "1003",
+        description: "zone_x",
+        robot_name: "magnus",
+        state: "Failed",
+        task_type: "Clean",
+        priority: 1,
+        start_time: 1500,
+        end_time: 1540,
+        progress: "42"
+    };
+
+    const delayedState  = {
+        task_id: "1003",
+        description: "zone_x",
+        robot_name: "magnus",
+        state: "Delayed",
+        task_type: "Clean",
+        priority: 1,
+        start_time: 1500,
+        end_time: 1540,
+        progress: "42"
+    };
+
+    const cancelledState  = {
+        task_id: "1003",
+        description: "zone_x",
+        robot_name: "magnus",
+        state: "Cancelled",
+        task_type: "Clean",
+        priority: 1,
+        start_time: 1500,
+        end_time: 1540,
+        progress: "42"
+    };
+
+    it("should render", () => {
+        render(<TaskCard taskState={exampleState} />);
+        expect(screen.getByRole('task-details')).toBeInTheDocument();
+    });
+
+    it("should render a red X when task has failed", () => {
+        const { container } = render(<TaskCard taskState={failedState} />);
+        expect(container.getElementsByClassName("ant-progress-status-exception").length).toBe(1);
+    });
+
+    it("should render Delayed description when task is delayed", () => {
+        render(<TaskCard taskState={delayedState} />);
+        expect(screen.getByText('Delayed')).toBeInTheDocument();
+    });
+
+    it("should render Cancelled state with disabled cancel button when task is cancelled", () => {
+        render(<TaskCard taskState={cancelledState} />);
+        expect(screen.getByText('Cancelled')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cancel Task'})).toBeDisabled();
+    });
+});

--- a/rmf_panel/src/app.tsx
+++ b/rmf_panel/src/app.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Divider from '@material-ui/core/Divider';
+import Header from "./components/fixed-components/header";
+import PanelsContainer from './components/panels-container';
+import Footer from './components/fixed-components/footer';
+import NavTabs from './components/fixed-components/tabs';
+import { WorldContext, World } from './components/fixed-components/app-context';
+import { getDashboardConfig } from './components/services';
+
+export default function App(): React.ReactElement {
+    const currWorld = React.useContext(WorldContext);
+    const [currentWorld, setCurrentWorld] = React.useState(currWorld);
+    const [worldName, setWorldName] = React.useState('');
+    
+    const setDefaultConfig = async () => {
+        const defaultConfig = await getDashboardConfig();
+        setCurrentWorld({map: World.Office, config: defaultConfig});
+        setWorldName(defaultConfig.world_name);
+    };
+
+    React.useEffect(() => {
+       setDefaultConfig();
+    }, []);
+
+    return (
+        <div>
+            <WorldContext.Provider value={currentWorld}>
+                <Header />
+                <NavTabs worldName={worldName} />
+                <Divider variant="middle" />
+                <PanelsContainer />
+                <Divider variant="middle"/>
+                <Footer />
+            </WorldContext.Provider>
+        </div>
+    )
+}

--- a/rmf_panel/src/components/fixed-components/app-context.tsx
+++ b/rmf_panel/src/components/fixed-components/app-context.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+// TODO: Rethink if different world tabs are necessary (Office)
+export const Worlds = {
+    0: "Office",
+    1: "Airport",
+    2: "Clinic",
+    3: "Hotel"
+}
+
+export enum World {
+    Office = 0,
+    Airport,
+    Clinic,
+    Hotel,
+}
+
+export type WorldContextType = {
+    map: World,
+    config: any
+}
+
+export const WorldContext = React.createContext<WorldContextType>({ map: World.Office, config: {} });

--- a/rmf_panel/src/components/fixed-components/footer.tsx
+++ b/rmf_panel/src/components/fixed-components/footer.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Typography from '@material-ui/core/Typography';
+import { useFooterStyles } from "../styles";
+
+const Footer = () : React.ReactElement => {
+    const classes = useFooterStyles();
+    
+    return (
+        <footer className={classes.footer} role="footer">
+            <Typography variant="subtitle1">Developed by Open Robotics 2020</Typography>
+            <Typography variant="subtitle1">RMF Demo Panel is Powered by RMF</Typography>
+            <img src="https://static1.squarespace.com/static/57daacd7f7e0ab084d5efbf0/t/5e3a197c40f86549694b35a7/1604624644022/?format=1500w" alt="osrf_logo" width="80" height="30"/>
+        </footer>
+    )
+}
+
+export default Footer;

--- a/rmf_panel/src/components/fixed-components/header.tsx
+++ b/rmf_panel/src/components/fixed-components/header.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+
+const Header = () : React.ReactElement => {
+    return (
+        <div role="header">
+            <AppBar id="appbar" position="sticky">
+                <Toolbar>
+                    <Typography variant="h4">RMF Panel</Typography>
+                </Toolbar>
+            </AppBar>
+        </div>
+    )
+}
+
+export default Header;

--- a/rmf_panel/src/components/fixed-components/notification-snackbar.tsx
+++ b/rmf_panel/src/components/fixed-components/notification-snackbar.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
+import Snackbar from '@material-ui/core/Snackbar';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+
+function Alert(props: AlertProps) {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
+
+export enum NotificationTypes {
+  Success = 'success',
+  Warning = 'warning',
+  Error = 'error',
+  Info = 'info'
+}
+
+interface SnackbarProps {
+  type: NotificationTypes;
+  message: string;
+  closeSnackbarCallback: () => void;
+}
+
+export const NotificationSnackbar = (props: SnackbarProps) => {
+  const { type, message, closeSnackbarCallback } = props;
+  const [open, setOpen] = React.useState(true);
+
+  const handleClose = (event: React.SyntheticEvent | React.MouseEvent, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpen(false);
+    closeSnackbarCallback();
+  };
+
+  return (
+      <Snackbar
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        open={open}
+        autoHideDuration={4000}
+        onClose={handleClose}
+        action={
+          <React.Fragment>
+            <IconButton size="small" aria-label="close" color="inherit" onClick={handleClose}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </React.Fragment>
+        }
+      >
+        <Alert onClose={handleClose} severity={type}>{message}</Alert>
+      </Snackbar>
+  )
+}

--- a/rmf_panel/src/components/fixed-components/rostime-clock.tsx
+++ b/rmf_panel/src/components/fixed-components/rostime-clock.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import { socket } from '../socket';
+
+const RostimeClock = () => {
+    const [time, setTime] = React.useState('');
+
+    React.useEffect(() => {
+        let isSubscribed = true;
+        socket.on("ros_time", msg => {
+            if(isSubscribed) {
+                const timeData = Math.floor(msg / 3600) + ":" +
+                (Math.floor(msg / 60) % 60) + ":" +
+                (msg % 60);
+                setTime(timeData);
+            }
+        });
+        return () => {isSubscribed = false}
+    }, []);
+
+    return (
+        <Box>
+            <Typography variant='h6' align="center" gutterBottom role="clock-time">Time is: {time}</Typography>
+        </Box>
+    )
+}
+
+export default RostimeClock;

--- a/rmf_panel/src/components/fixed-components/tabs.tsx
+++ b/rmf_panel/src/components/fixed-components/tabs.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { makeStyles, withStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+
+interface StyledTabsProps {
+  value: number;
+  onChange: (event: React.ChangeEvent<{}>, newValue: number) => void;
+}
+
+const StyledTabs = withStyles({
+  indicator: {
+    display: 'flex',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+    '& > span': {
+      maxWidth: 40,
+      width: '100%',
+      backgroundColor: '#635ee7',
+    },
+  },
+})((props: StyledTabsProps) => <Tabs {...props} TabIndicatorProps={{ children: <span /> }} />);
+
+interface StyledTabProps {
+  label: string;
+}
+
+const StyledTab = withStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      textTransform: 'none',
+      color: '#2e1534',
+      fontWeight: theme.typography.fontWeightRegular,
+      fontSize: theme.typography.pxToRem(15),
+      marginRight: theme.spacing(0.5),
+      '&:focus': {
+        opacity: 1,
+      },
+    },
+  }),
+)((props: StyledTabProps) => <Tab disableRipple {...props} />);
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    flexGrow: 1,
+  },
+  padding: {
+    padding: theme.spacing(2),
+  },
+  tabs: {
+    backgroundColor: '#fafafa',
+  },
+  tabContainer: {
+      paddingTop: theme.spacing(1),
+      paddingBottom: theme.spacing(1)
+  }
+})); 
+
+interface NavTabsProps {
+  worldName: string;
+}
+
+const NavTabs: React.FC<NavTabsProps> = (props: NavTabsProps) => {
+  const { worldName } = props;
+  const classes = useStyles();
+  const [value, setValue] = React.useState(0);
+  
+   
+  const handleChange = async (event: React.ChangeEvent<{}>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <div className={classes.root} role="nav-tabs">
+      <div className={classes.tabs}>
+        <StyledTabs value={value} onChange={handleChange} aria-label="styled tabs example">
+          <StyledTab label={`RMF: ${worldName}`} />
+        </StyledTabs>
+      </div>
+    </div>
+  );
+}
+
+export default NavTabs; 

--- a/rmf_panel/src/components/forms/cleaning-form.tsx
+++ b/rmf_panel/src/components/forms/cleaning-form.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import Autocomplete, { AutocompleteRenderInputParams } from '@material-ui/lab/Autocomplete';
+import { useFormStyles } from "../styles";
+import { NotificationSnackbar, NotificationTypes } from '../fixed-components/notification-snackbar';
+
+interface CleaningFormProps {
+  cleaningZones: string[],
+  submitRequest: (request: {}) => Promise<any>;
+  timeAndPriority: {
+    minsFromNow: number,
+    priority: number,
+    setTimeError: React.Dispatch<React.SetStateAction<string>>,
+    setMinsFromNow: React.Dispatch<React.SetStateAction<number>>,
+    setPriority: React.Dispatch<React.SetStateAction<number>>,
+    setPriorityError: React.Dispatch<React.SetStateAction<string>>
+  }
+}
+
+export const CleaningForm = (props: CleaningFormProps): React.ReactElement => {
+  const { cleaningZones, submitRequest, timeAndPriority } = props;
+  const { minsFromNow, priority, setTimeError, setMinsFromNow, setPriority, setPriorityError } = timeAndPriority;
+  const [allZones, setZones] = React.useState(cleaningZones);
+  const [targetZone, setTargetZone] = React.useState('');
+
+  //snackbar
+  const [snackbarMessage, setSnackbarMessage] = React.useState('');
+  const [openSnackbar, setOpenSnackbar] = React.useState(false);
+  const [messageType, setMessageType] = React.useState(NotificationTypes.Success);
+
+  //errors
+  const [zoneError, setZoneError] = React.useState("");
+  
+  const classes = useFormStyles();
+  
+  React.useEffect(() => {
+    setZones(cleaningZones);
+  }, [cleaningZones]);
+
+  const cleanUpForm = () => {
+    setMinsFromNow(0);
+    setTargetZone("");
+    setPriority(0);
+    setPriorityError("");
+  }
+
+  const isFormValid = () => {
+    let isValid = true;
+    if(priority < 0 || priority > 1) {
+      setPriorityError("Priority can only be 0 or 1");
+      isValid = false;
+    }
+    if(minsFromNow < 0) {
+      setTimeError("Start time cannot be negative");
+      isValid = false;
+    }
+    if(targetZone.length === 0) {
+      setZoneError("Cleaning zone cannot be an empty field");
+      isValid = false;
+    }
+    return isValid;
+  }
+
+  const showErrorSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Error);
+    setOpenSnackbar(true);
+  }
+
+  const showSuccessSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Success);
+    setOpenSnackbar(true);
+  }
+
+  const createRequest = () => {
+    let start_time = minsFromNow;
+    let cleaning_zone = targetZone;
+    let request = {};
+    let priority_option = priority;
+    request = { task_type: "Clean",
+                start_time: start_time,
+                priority: priority_option,
+                description: {'cleaning_zone': cleaning_zone} }
+    return request;
+  }
+
+  const handleSubmit = async (ev: React.FormEvent) => {
+    try {
+      ev.preventDefault();
+      if(isFormValid()) {
+        let request = createRequest();
+        let response = await submitRequest(request);
+        if (response && response["task_id"] === '') {
+          showErrorSnackbar(`Cleaning Request failed! ${response["error_msg"]}`);
+        } else {
+          showSuccessSnackbar(`Request submitted successfully! Task ID: [${response["task_id"]}]`)
+        }
+        cleanUpForm();
+      }
+    } catch(err) {
+      return;
+    }
+  }
+
+    return (
+        <Box className={classes.form} role="cleaning-form">
+            <div className={classes.divForm}>
+            <Typography variant="h6">Schedule a Clean Request</Typography>
+                <Autocomplete
+                options={allZones}
+                getOptionLabel={(zone) => zone}
+                id="set-cleaning-zone"
+                openOnFocus
+                onChange={(_, value) => setTargetZone(value)}
+                renderInput={(params: AutocompleteRenderInputParams) => <TextField {...params} label="Pick a zone" variant="outlined" margin="normal" helperText={zoneError} error={!!zoneError}/>}
+                value={targetZone ? targetZone : null}
+                />
+            </div>
+            <div className={classes.buttonContainer}>
+                <Button variant="contained" color="primary" onClick={handleSubmit} className={classes.button}>Submit Request</Button>
+                 {openSnackbar && <NotificationSnackbar type={messageType} message={snackbarMessage} closeSnackbarCallback={() => setOpenSnackbar(false)} />}
+            </div>
+        </Box>
+    );
+} 
+
+export default CleaningForm;

--- a/rmf_panel/src/components/forms/delivery-form.tsx
+++ b/rmf_panel/src/components/forms/delivery-form.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import Autocomplete, { AutocompleteRenderInputParams } from '@material-ui/lab/Autocomplete';
+import { useFormStyles } from '../styles';
+import { NotificationSnackbar, NotificationTypes } from '../fixed-components/notification-snackbar';
+
+interface DeliveryFormProps {
+  deliveryOptions: {}
+  submitRequest: (request: {}) => Promise<any>;
+  timeAndPriority: {
+    minsFromNow: number,
+    priority: number,
+    setTimeError: React.Dispatch<React.SetStateAction<string>>,
+    setMinsFromNow: React.Dispatch<React.SetStateAction<number>>,
+    setPriority: React.Dispatch<React.SetStateAction<number>>,
+    setPriorityError: React.Dispatch<React.SetStateAction<string>>
+  }
+}
+
+const DeliveryForm = (props: DeliveryFormProps): React.ReactElement => {
+  const { deliveryOptions, submitRequest, timeAndPriority } = props;
+  const { minsFromNow, priority, setTimeError, setMinsFromNow, setPriority, setPriorityError } = timeAndPriority;
+  const classes = useFormStyles();
+  const [deliveryTask, setDeliveryTask] = React.useState("");
+  const [deliveryOptionKeys, setDeliveryOptionKeys] = React.useState([]);
+
+  //snackbar
+  const [snackbarMessage, setSnackbarMessage] = React.useState('');
+  const [openSnackbar, setOpenSnackbar] = React.useState(false);
+  const [messageType, setMessageType] = React.useState(NotificationTypes.Success);
+
+  //errors
+  const [taskError, setTaskError] = React.useState("");
+
+  React.useEffect(() => {
+    let optionKeys = [];
+    for (const key in deliveryOptions) {
+        optionKeys.push(key);
+    }
+    setDeliveryOptionKeys(optionKeys);
+  }, [deliveryOptions]);
+
+  const isFormValid = () => {
+    let isValid = true;
+    if(priority < 0 || priority > 1) {
+      setPriorityError("Priority can only be 0 or 1");
+      isValid = false;
+    }
+    if(deliveryTask === "") {
+      setTaskError("Please select a delivery task");
+      isValid = false;
+    }
+    if(minsFromNow < 0) {
+      setTimeError("Start time cannot be negative");
+      isValid = false;
+    }
+    return isValid;
+  }
+
+  const showErrorSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Error);
+    setOpenSnackbar(true);
+  }
+
+  const showSuccessSnackbar = (message: string): void => {
+    setSnackbarMessage (message);
+    setMessageType(NotificationTypes.Success);
+    setOpenSnackbar(true);
+  }
+
+  const cleanUpForm = () => {
+    setDeliveryTask("");
+    setTaskError("");
+    setTimeError("");
+    setMinsFromNow(0);
+    setPriority(0);
+    setPriorityError("");
+  }
+  
+  const createTaskDescription = (deliveryTask: string): {} => {
+    let newDelivery = deliveryOptions[deliveryTask];
+    return newDelivery;
+  }
+
+  const createRequest = () => {
+    let start_time = minsFromNow;
+    let description = createTaskDescription(deliveryTask);
+    let request = {};
+    let priority_option = priority;
+    request = { task_type: "Delivery",
+                start_time: start_time,
+                priority: priority_option,
+                description: description }
+    return request;
+  }
+  
+  const handleSubmit = async (ev: React.FormEvent) => {
+    try {
+      ev.preventDefault();
+      if(isFormValid()) {
+        let request = createRequest();
+        let response = await submitRequest(request);
+        if (response && response["task_id"] === '') {
+          showErrorSnackbar(`Delivery Request failed! ${response["error_msg"]}`);
+        } else {
+          showSuccessSnackbar(`Request submitted successfully! Task ID: [${response["task_id"]}]`)
+        }
+        cleanUpForm();
+      }
+    } catch(err) {
+      return;
+    }
+  }
+
+  return (
+    <Box className={classes.form} role="delivery-form">
+      <div className={classes.divForm}>
+        <Typography variant="h6">Schedule a Delivery Request</Typography>
+        <Autocomplete
+          options={deliveryOptionKeys}
+          getOptionLabel={(option: any) => option}
+          id="set-delivery-task"
+          openOnFocus
+          onChange={(_, value) => setDeliveryTask(value)}
+          renderInput={(params: AutocompleteRenderInputParams) => <TextField {...params} label="Select delivery task" variant="outlined" margin="normal" error={!!taskError} helperText={taskError} />}
+          value={deliveryTask ? deliveryTask : null}
+        />
+      </div>
+      <div className={classes.buttonContainer}>
+        <Button variant="contained" color="primary" onClick={handleSubmit} className={classes.button}>Submit Request</Button>
+        {openSnackbar && <NotificationSnackbar type={messageType} message={snackbarMessage} closeSnackbarCallback={() => setOpenSnackbar(false)} />}
+      </div>
+    </Box>
+  )
+}
+
+export default DeliveryForm;

--- a/rmf_panel/src/components/forms/loop-request-form.tsx
+++ b/rmf_panel/src/components/forms/loop-request-form.tsx
@@ -1,0 +1,193 @@
+import React, { SetStateAction } from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import Autocomplete, { AutocompleteRenderInputParams } from '@material-ui/lab/Autocomplete';
+import { useFormStyles } from '../styles';
+import { NotificationSnackbar, NotificationTypes } from '../fixed-components/notification-snackbar';
+
+interface LoopDescription {
+  num_loops: number,
+  start_name: string,
+  finish_name: string
+}
+
+interface LoopFormProps {
+  availablePlaces: string[]
+  submitRequest: (request: {}) => Promise<any>;
+  timeAndPriority: {
+    minsFromNow: number,
+    priority: number,
+    setTimeError: React.Dispatch<React.SetStateAction<string>>,
+    setMinsFromNow: React.Dispatch<React.SetStateAction<number>>,
+    setPriority: React.Dispatch<React.SetStateAction<number>>,
+    setPriorityError: React.Dispatch<React.SetStateAction<string>>
+  }
+}
+
+const LoopRequestForm = (props: LoopFormProps): React.ReactElement => {
+  const { availablePlaces, submitRequest, timeAndPriority } = props;
+  const { minsFromNow, priority, setTimeError, setMinsFromNow, setPriority, setPriorityError } = timeAndPriority;
+  const classes = useFormStyles();
+  const [startLocation, setStartLocation] = React.useState("");
+  const [endLocation, setEndLocation] = React.useState("");
+  const [places, setPlaces] = React.useState(availablePlaces);
+  const [numLoops, setNumLoops] = React.useState(1);
+
+  //snackbar
+  const [snackbarMessage, setSnackbarMessage] = React.useState('');
+  const [openSnackbar, setOpenSnackbar] = React.useState(false);
+  const [messageType, setMessageType] = React.useState(NotificationTypes.Success);
+
+  //errors
+  const [numLoopsError, setNumLoopsError] = React.useState("");
+  const [locationError, setLocationError] = React.useState("");
+
+  React.useLayoutEffect(() => {
+    setPlaces(availablePlaces);
+  }, [availablePlaces]);
+
+  const isFormValid = (): boolean => {
+    let isValid = true;
+    if(priority < 0 || priority > 1) {
+      setPriorityError("Priority can only be 0 or 1");
+      isValid = false;
+    }
+    if(startLocation == endLocation) {
+      setLocationError("Start and end locations cannot be the same");
+      isValid = false;
+    }
+    if(startLocation == '' || endLocation == '') {
+      setLocationError('Please select a location');
+      isValid = false;
+    }
+    if(numLoops <= 0) {
+      setNumLoopsError("Number of loops can only be > 0");
+      isValid = false;
+    }
+    if(minsFromNow < 0) {
+      setTimeError("Start time cannot be negative");
+      isValid = false;
+    }
+    return isValid;
+  }
+
+  const showErrorSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Error);
+    setOpenSnackbar(true);
+  }
+
+  const showSuccessSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Success);
+    setOpenSnackbar(true);
+  }
+
+  const cleanUpForm = () => {
+    setStartLocation("");
+    setEndLocation("");
+    setNumLoops(1);
+    setMinsFromNow(0);
+    setPriority(0);
+    cleanUpError();
+  }
+
+  const cleanUpError = () => {
+      setLocationError('');
+      setNumLoopsError('');
+      setTimeError('');
+      setPriorityError('');
+  };
+
+  const createRequest = () => {
+    let description: LoopDescription = {
+      num_loops: numLoops,
+      start_name: startLocation,
+      finish_name: endLocation,
+    }
+    let start_time = minsFromNow;
+    let request = {};
+    let priority_option = priority;
+    request = { task_type: "Loop",
+                start_time: start_time,
+                priority: priority_option,
+                description: description }
+    return request;
+  }
+    
+  const handleSubmit = async (ev: React.FormEvent) => {
+    try {
+      ev.preventDefault();
+      if(isFormValid()) {
+        let request = createRequest();
+        let response = await submitRequest(request);
+        if (response && response["task_id"] === '') {
+          showErrorSnackbar(`Loop Request failed! ${response["error_msg"]}`);
+        } else {
+          showSuccessSnackbar(`Request submitted successfully! Task ID: [${response["task_id"]}]`)
+        }
+          cleanUpForm();
+        }
+    } catch(err) {
+        return;
+    }
+  }
+
+  return (
+        <Box className={classes.form} role="loop-request-form">
+            <div className={classes.divForm}>
+            <Typography variant="h6">Schedule a Loop Request</Typography>
+                <Autocomplete
+                options={places}
+                getOptionLabel={(place) => place}
+                id="set-start-location"
+                openOnFocus
+                onChange={(_, value) => setStartLocation(value)}
+                renderInput={(params: AutocompleteRenderInputParams) => 
+                  <TextField {...params} 
+                    label="Select start location" 
+                    variant="outlined" 
+                    margin="normal"
+                    error={!!locationError}
+                    helperText={locationError} 
+                  />}
+                value={startLocation ? startLocation : null}
+                />
+            </div>
+            <div className={classes.divForm}>
+                <Autocomplete id="set-end-location"
+                openOnFocus
+                options={places}
+                getOptionLabel={(place) => place}
+                onChange={(_, value) => setEndLocation(value)}
+                renderInput={(params: AutocompleteRenderInputParams) => <TextField {...params} label="Select end location" variant="outlined" margin="normal" error={!!locationError} helperText={locationError}/>}
+                value={endLocation ? endLocation : null}
+                />
+            </div>
+            <div className={classes.divForm}>
+                <TextField
+                  className={classes.input}
+                  onChange={(e) => {
+                  setNumLoops(e.target.value ? parseInt(e.target.value) : 0);
+                  }}
+                  placeholder="Set number of loops"
+                  type="number"
+                  value={numLoops || ''}
+                  label="Number of Loops"
+                  variant="outlined"
+                  id="set-num-loops"
+                  error={!!numLoopsError}
+                  helperText={numLoopsError}
+                />
+            </div>
+            <div className={classes.buttonContainer}>
+                <Button variant="contained" color="primary" onClick={handleSubmit} className={classes.button}>Submit Request</Button>
+                {openSnackbar && <NotificationSnackbar type={messageType} message={snackbarMessage} closeSnackbarCallback={() => setOpenSnackbar(false)} />}
+            </div>
+        </Box>
+    );
+}
+
+export default LoopRequestForm;

--- a/rmf_panel/src/components/forms/request-form.tsx
+++ b/rmf_panel/src/components/forms/request-form.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import Box from '@material-ui/core/Box';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import Autocomplete, { AutocompleteRenderInputParams } from '@material-ui/lab/Autocomplete';
+import { useFormStyles } from "../styles";
+import CleaningForm from './cleaning-form';
+import LoopRequestForm from './loop-request-form';
+import DeliveryForm from './delivery-form';
+import { WorldContext } from '../fixed-components/app-context';
+import { submitRequest } from '../services';
+
+const RequestForm = (): React.ReactElement => {
+    const { config } = React.useContext(WorldContext);
+    const [requestTypes, setRequestTypes] = React.useState(config.valid_task);
+    const [formType, setFormType] = React.useState('');
+    const [loopPlaces, setLoopPlaces] = React.useState([]);
+    const [deliveryOptions, setDeliveryOptions] = React.useState({});
+    const [cleaningZones, setCleaningZones] = React.useState([]);
+    const [minsFromNow, setMinsFromNow] = React.useState(0);
+    const [priority, setPriority] = React.useState(0);
+    const [timeError, setTimeError] = React.useState("");
+    const [priorityError, setPriorityError] = React.useState("");
+
+    React.useEffect(() => {
+        if(Object.keys(config).length > 0) {
+            setRequestTypes(config.valid_task);
+            setLoopPlaces(config.task.Loop.places);
+            setDeliveryOptions(config.task.Delivery.option);
+            setCleaningZones(config.task.Clean.option);
+        } else {
+            setRequestTypes([]);
+            setFormType('');
+            setLoopPlaces([]);
+            setDeliveryOptions({});
+            setCleaningZones([]);
+        }
+    }, [config]);
+
+    const returnFormType = (formType: string) => {
+        const timeAndPriority = { minsFromNow, priority, setTimeError, setMinsFromNow, setPriority, setPriorityError };
+        switch (formType) {
+            case "Loop":
+                return <LoopRequestForm availablePlaces={loopPlaces} submitRequest={submitRequest} timeAndPriority={timeAndPriority}/>
+            case "Delivery": 
+                return <DeliveryForm deliveryOptions={deliveryOptions} submitRequest={submitRequest} timeAndPriority={timeAndPriority}/>
+            case "Clean":
+                return <CleaningForm cleaningZones={cleaningZones} submitRequest={submitRequest} timeAndPriority={timeAndPriority}/>
+        }
+    }
+
+    const classes = useFormStyles();
+    
+    return (
+        <Box className={classes.form}>
+            <div className={classes.divForm}>
+            <Typography variant="h6">Submit a Task</Typography>
+                <Autocomplete
+                options={requestTypes}
+                getOptionLabel={(requestType) => requestType}
+                id="set-form-type"
+                openOnFocus
+                defaultValue={formType}
+                onChange={(_, value) => setFormType(value)}
+                renderInput={(params: AutocompleteRenderInputParams) => <TextField {...params} label="Select a request type" variant="outlined" margin="normal" />}
+                />
+            </div>
+            <div className={classes.divForm}>
+                <TextField
+                className={classes.input}
+                onChange={(e) => {
+                setMinsFromNow(e.target.value ? parseInt(e.target.value) : 0);
+                }}
+                placeholder="Set start time (mins from now)"
+                type="number"
+                value={minsFromNow || 0}
+                label="Set start time (mins from now)"
+                variant="outlined"
+                id="set-start-time"
+                error={!!timeError}
+                helperText={timeError}
+                />
+            </div>
+            <div className={classes.divForm}>
+                <TextField
+                className={classes.input}
+                onChange={(e) => {
+                setPriority(e.target.value ? parseInt(e.target.value) : 0);
+                }}
+                placeholder="0"
+                type="number"
+                value={priority}
+                label="Choose a priority (Default: 0)"
+                variant="outlined"
+                id="set-priority"
+                error={!!priorityError}
+                helperText={priorityError}
+                InputProps={{ inputProps: { max: 1, min: 0 } }}
+                >
+                </TextField>
+            </div>
+            <div className={classes.divForm}>
+                {formType && returnFormType(formType)}
+            </div>
+        </Box>
+    )
+}
+
+export default RequestForm;

--- a/rmf_panel/src/components/forms/scheduled-task-form.tsx
+++ b/rmf_panel/src/components/forms/scheduled-task-form.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import { WorldContext } from '../fixed-components/app-context';
+import { useFormStyles } from "../styles";
+import { NotificationTypes, NotificationSnackbar } from "../fixed-components/notification-snackbar";
+
+interface TaskRequest {
+  task_type: string,
+  start_time: number,
+  priority: number,
+  description: any
+}
+
+interface ScheduledTaskFormProps {
+  submitTaskList: (taskList: any[]) => NodeJS.Timeout[];
+}
+
+const ScheduledTaskForm = (props: ScheduledTaskFormProps): React.ReactElement => {
+  const { config } = React.useContext(WorldContext);
+  const { submitTaskList } = props;
+  const [uploadedFile, setUploadedFile] = React.useState(null);
+  const [taskList, setTaskList] = React.useState<string | ArrayBuffer>('');
+  const [deliveryOptions, setDeliveryOptions] = React.useState({});
+  const [snackbarMessage, setSnackbarMessage] = React.useState('');
+  const [openSnackbar, setOpenSnackbar] = React.useState(false);
+  const [messageType, setMessageType] = React.useState(NotificationTypes.Success);
+  const placeholder = `eg. [
+{"task_type":"Loop", "start_time":0, "priority": 0, "description": {"num_loops":5, "start_name":"coe", "finish_name":"lounge"}},
+{"task_type":"Delivery", "start_time":0, "priority": 0,"description": {"option": "coke"}},
+{"task_type":"Loop", "start_time":0, "priority": 0,"description": {"num_loops":5, "start_name":"cubicle_2", "finish_name":"supplies"}}
+]`
+
+  React.useEffect(() => {
+    if(Object.keys(config).length > 0) {
+      setDeliveryOptions(config.task.Delivery.option);
+    } else {
+      setDeliveryOptions({});
+    }
+  }, [config]);
+
+  const createTaskDescription = (deliveryTask: string) => {
+    let newDesc = deliveryOptions[deliveryTask];
+      return newDesc;
+  }
+
+  const convertTaskList = () => {
+    let globalTaskList = [];
+    let tempTaskList: string | any = taskList;
+    let jsonTaskList = JSON.parse(tempTaskList);
+    globalTaskList = jsonTaskList.map((task: TaskRequest) => {
+      if(task.task_type == "Delivery") {
+        let taskDesc = createTaskDescription(task.description.option);
+        return {
+          task_type: task.task_type,
+          start_time: task.start_time,
+          priority: task.priority,
+          description: taskDesc
+        }
+      } else {
+        return task;
+      }
+    });
+    return globalTaskList;
+  }
+
+  const showErrorSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Error);
+    setOpenSnackbar(true);
+  }
+
+  const showSuccessSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Success);
+    setOpenSnackbar(true);
+  }
+  
+  const isFormValid = () => {
+    if(taskList === "" || taskList === `[]` || taskList === `{}`) {
+      showErrorSnackbar("Unable to submit an empty task list");
+      return false;
+    }
+    //including handling of incomplete forms (eg. missing closing ])
+    return true;
+  }
+  
+  const handleSubmit = (ev: React.FormEvent) => {
+    try {
+      ev.preventDefault();
+      if(isFormValid()) {
+        let globalList = convertTaskList();
+        let responseList = submitTaskList(globalList);
+        if(responseList.length === globalList.length) {
+          showSuccessSnackbar("Task List submitted successfully!");
+        } else {
+          showErrorSnackbar("Error: Unable to submit task list");
+        }
+        setTaskList('');
+        setUploadedFile(null);
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  }
+  
+  const readTaskFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let file = e.target.files[0];
+    setUploadedFile(file);
+    const reader = new FileReader();
+    reader.onload = function(event) {
+      let result = event.target.result;
+      setTaskList(result);
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  }
+
+  const onInputClick = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+    (e.target as HTMLInputElement).value = '';
+  }
+  
+  const classes = useFormStyles();
+  
+  return (
+    <Box className={classes.form} role="scheduled-task-form">
+        <div className={classes.divForm}>
+          <Typography variant="h6">Submit a List of Tasks</Typography>
+          </div>
+        <div className={classes.buttonContainer}>
+          <Button variant="contained" color="primary" className={classes.selectButton}>
+            <label id="fileLabel" htmlFor="task_file" className={classes.label}>{uploadedFile ? uploadedFile.name : 'Select File'}</label>
+            <input className={classes.fileInput} type="file" id="task_file" name="task_file" onChange={readTaskFile} onClick={onInputClick}/>
+          </Button>
+        </div>
+        <div className={classes.divForm}>
+          <TextField
+                multiline
+                rows={5}
+                placeholder={placeholder}
+                variant="outlined"
+                fullWidth
+                value={taskList || ''}
+                onChange={(e) => setTaskList(e.target.value)}
+              />
+        </div>
+        <div className={classes.buttonContainer}>
+          <Button variant="contained" color="primary" onClick={handleSubmit} className={classes.button}>Submit Task List</Button>
+          {openSnackbar && <NotificationSnackbar type={messageType} message={snackbarMessage} closeSnackbarCallback={() => setOpenSnackbar(false)} />}
+        </div>
+    </Box>
+  )
+}
+
+export default ScheduledTaskForm;

--- a/rmf_panel/src/components/panels-container.tsx
+++ b/rmf_panel/src/components/panels-container.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import Divider from '@material-ui/core/Divider';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import ScheduledTaskForm from './forms/scheduled-task-form';
+import RobotContainer from './robots/robot-cards-container';
+import TasksContainer from './tasks/tasks-container';
+import RostimeClock from './fixed-components/rostime-clock';
+import RequestForm from './forms/request-form';
+import { usePanelContainerStyles } from "./styles";
+import { submitAllTasks } from './services';
+
+const PanelsContainer = (): React.ReactElement => {
+    const classes = usePanelContainerStyles();
+
+    return (
+            <Grid className={classes.panels}>
+                <Grid container direction="row" alignContent="center" justify="center">
+                    <Grid item xs={12}>
+                        <RostimeClock />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Typography className={classes.centered} variant="h4">Task Submissions</Typography>
+                    </Grid>
+                </Grid>
+                <Grid container direction="row" justify="space-evenly" alignItems="flex-start" spacing={2}>
+                    <Grid item xs={5}>
+                        <RequestForm />
+                    </Grid>
+                    <Grid item xs={5}>
+                        <ScheduledTaskForm submitTaskList={submitAllTasks} />
+                    </Grid>
+                </Grid>
+                <Divider variant="middle"/>
+                <Grid container direction="row" alignContent="center" justify="center">
+                    <Grid item xs={12}>
+                        <Typography className={classes.centered} variant="h4">Robots & Tasks Summaries</Typography>
+                    </Grid>
+                </Grid>
+                 <Grid container direction="row" justify="space-evenly" alignItems="flex-start" spacing={2}>
+                    <Grid item xs={5}>
+                        <RobotContainer />
+                    </Grid>
+                    <Grid item xs={6}>
+                        <TasksContainer />
+                    </Grid>
+                </Grid>
+            </Grid>
+    )
+}
+
+export default PanelsContainer;

--- a/rmf_panel/src/components/robots/robot-card.tsx
+++ b/rmf_panel/src/components/robots/robot-card.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import Progress from 'antd/lib/progress';
+import { useRobotCardStyles } from '../styles';
+import BatteryChargingFullIcon from '@material-ui/icons/BatteryChargingFull';
+import Dock from '@material-ui/icons/Dock';
+
+interface RobotCardProps {
+  robotState: {
+    robot_name: string;
+    fleet_name: string;
+    assignments: string[];
+    mode: string;
+    battery_percent: string;
+    level_name: string;
+  };
+}
+
+export const RobotCard = (props: RobotCardProps) : React.ReactElement => {
+    const { robotState } = props
+    let battery: number = parseFloat(parseFloat(robotState.battery_percent).toFixed(2));
+    const classes = useRobotCardStyles();
+
+    const returnStatusIcon = (mode: string) => {
+      switch(mode) {
+        case "Charging-1":
+          return <BatteryChargingFullIcon />
+        case "Dock/Clean-7":
+          return <Dock />
+      }
+    }
+
+    const joinAssignments = (assignments: string[]) => {
+      if(assignments.length > 1) {
+        let joinedAssignments = assignments.map((value, index) => {
+          if(index === (assignments.length - 1)){
+            return value;
+          } else {
+            return value.concat(" ➜")
+          }
+        });
+        return joinedAssignments.join("");
+      } else if (assignments.length == 1) {
+        return assignments[0];
+      } else {
+        return '';
+      }
+    }
+
+    return (
+        <Card className={classes.root} variant="outlined" role="robot-details">
+            <CardContent>
+              <Grid container>
+                <Grid item xs={12}>
+                    <Typography variant="h6" color="textSecondary" className={classes.text}>
+                      {robotState.robot_name}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Typography variant="subtitle1" color="textSecondary" className={classes.text}>
+                      {robotState.fleet_name}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={5}>
+                    <Typography variant="subtitle2" color="textSecondary" gutterBottom>
+                      Assigned Tasks
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={7}><Typography>{joinAssignments(robotState.assignments)}</Typography></Grid>
+                  <Grid item xs={5}>
+                    <Typography variant="subtitle2" color="textSecondary" gutterBottom>
+                      Status
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={7}><Typography>{robotState.mode}</Typography></Grid>
+                  <Grid item xs={5}>
+                    <Typography variant="subtitle2" color="textSecondary" gutterBottom>
+                      Battery
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={6}>
+                    <Progress percent={battery} size="small" width={50}/>
+                  </Grid>
+                  <Grid item xs={5}>
+                    <Typography variant="subtitle2" color="textSecondary">
+                      Location
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={7}><Typography>{robotState.level_name}</Typography></Grid>
+                  <Grid item container direction="column" alignItems="flex-end" justify="flex-end">{returnStatusIcon(robotState.mode)}</Grid>
+              </Grid>
+            </CardContent>
+        </Card>
+    );                                                                
+}

--- a/rmf_panel/src/components/robots/robot-cards-container.tsx
+++ b/rmf_panel/src/components/robots/robot-cards-container.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { RobotCard } from './robot-card';
+import { useContainerStyles } from '../styles';
+import { getRobots } from "../services";
+import { socket } from '../socket';
+
+const RobotContainer = () : React.ReactElement => {
+    const classes = useContainerStyles();
+    const [robotStates, setRobotStates] = React.useState([]);
+
+    const refreshRobotData = async () => {
+        let updatedData = await getRobots();
+        if(updatedData != robotStates) {
+            setRobotStates(updatedData);
+        }
+    }
+
+    React.useEffect(() => {
+        let isSubscribed = true;
+        socket.on("robot_states", robotData => {
+            if(isSubscribed) {
+                setRobotStates(robotData);
+            }
+        });
+        return () => {isSubscribed = false};
+    });
+
+    const allRobots = robotStates.map(robotState => {
+        return <Grid item><RobotCard robotState={robotState} /></Grid>
+    });
+
+    return (
+        <Box className={classes.container}>
+            <Typography variant="h5">Robots</Typography>
+            <Button variant="outlined" onClick={refreshRobotData}>Refresh</Button>
+            <Grid container className={classes.grid} >
+                {allRobots}
+            </Grid>
+        </Box>
+    )
+}
+export default RobotContainer;

--- a/rmf_panel/src/components/services.tsx
+++ b/rmf_panel/src/components/services.tsx
@@ -1,0 +1,86 @@
+const API_SERVER_ADD = "http://localhost:8080"
+const GUI_SERVER_ADD = "http://localhost:5000"
+
+//API endpoints
+export const getRobots = async () => {
+    try {
+        let response = await fetch(API_SERVER_ADD + '/robot_list');
+        if(response) {
+            let data = await response.json()
+            console.log("Populate robots: ", data);
+            return data;
+        } else {
+            return;
+        }
+    } catch (err) {
+        throw new Error(err.message);
+    }
+}
+
+export const getTasks = async () => {
+    try {
+        let response = await fetch(API_SERVER_ADD + '/task_list');
+        if(response) {
+            let data = await response.json()
+            console.log("Populate tasks: ", data);
+            return data;
+        }
+    } catch (err) {
+        throw new Error(err.message);
+    }
+}
+
+export const submitRequest = async (request: {}) => {
+    try {
+        let response = await fetch(API_SERVER_ADD + '/submit_task', {
+            method: "POST",
+            body: JSON.stringify(request),
+            headers: {
+                "Content-type": "application/json; charset=UTF-8"
+            }
+        })
+        .then(res => res.json());
+        return response;
+      } catch (err) {
+        return err;
+      }
+}
+
+export const cancelTask = async (id: string) => {
+    try {
+        let response = await fetch(API_SERVER_ADD + '/cancel_task', {
+            method: "POST",
+            body: JSON.stringify({ task_id: id }),
+            headers: {
+                "Content-type": "application/json; charset=UTF-8"
+            }
+        })
+        .then(res => res.json())
+        return response;
+    } catch (err) {
+        return err;
+    }
+}
+
+export const submitAllTasks = (taskList: any[]) => {
+    let i = 0;
+    let timerIdList = taskList.map((task) => {
+        return setTimeout(async () => {
+            await submitRequest(task);
+        }, 900*(++i));
+    });
+    return timerIdList;
+}
+
+export const getDashboardConfig = async () => {
+    try {
+        let response = await fetch(GUI_SERVER_ADD + '/dashboard_config');
+        if(response) {
+            let data = await response.json()
+            console.log("Get Dashboard Config", data);
+            return data;
+        }
+    } catch (err) {
+        throw new Error(err.message);
+    }
+}

--- a/rmf_panel/src/components/services.tsx
+++ b/rmf_panel/src/components/services.tsx
@@ -1,5 +1,4 @@
-const API_SERVER_ADD = "http://localhost:8080"
-const GUI_SERVER_ADD = "http://localhost:5000"
+const API_SERVER_ADD = "http://localhost:8083"  /// TODO: make this configurable on GUI
 
 //API endpoints
 export const getRobots = async () => {
@@ -74,7 +73,7 @@ export const submitAllTasks = (taskList: any[]) => {
 
 export const getDashboardConfig = async () => {
     try {
-        let response = await fetch(GUI_SERVER_ADD + '/dashboard_config');
+        let response = await fetch(API_SERVER_ADD + '/dashboard_config');
         if(response) {
             let data = await response.json()
             console.log("Get Dashboard Config", data);

--- a/rmf_panel/src/components/socket.tsx
+++ b/rmf_panel/src/components/socket.tsx
@@ -1,5 +1,6 @@
 import io from 'socket.io-client';
 
-const ENDPOINT = "http://localhost:8080/status_updates"
+/// TODO: make this configurable on GUI
+const ENDPOINT = "http://localhost:8083/status_updates"
 
 export const socket = io.connect(ENDPOINT);

--- a/rmf_panel/src/components/socket.tsx
+++ b/rmf_panel/src/components/socket.tsx
@@ -1,0 +1,5 @@
+import io from 'socket.io-client';
+
+const ENDPOINT = "http://localhost:8080/status_updates"
+
+export const socket = io.connect(ENDPOINT);

--- a/rmf_panel/src/components/styled-components/styled-chip.tsx
+++ b/rmf_panel/src/components/styled-components/styled-chip.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {  makeStyles } from '@material-ui/core/styles';
+import Chip from '@material-ui/core/Chip';
+import { red, orange, blue, teal, grey, purple, cyan } from '@material-ui/core/colors';
+
+interface StyledChipProps {
+    state: string
+}
+
+const useStyles = (bgCol: string) => makeStyles({
+    root: {
+        background: bgCol,
+        color: 'white',
+        height: 24,
+        verticalAlign: 'middle',
+    }
+});
+
+const returnChipColor = (state: string): string => {
+    switch(state) {
+        case "Queued": 
+            return cyan[500]
+        case "Active/Executing":
+            return blue[500]
+        case "Completed":
+            return teal[500]
+        case "Failed":
+            return red[400]
+        case "Cancelled":
+            return grey[400]
+        case "Pending":
+            return purple[400]
+        case "Delayed":
+            return orange[300]
+    }
+}
+
+const StyledChip = (props: StyledChipProps) => {
+    const { state } = props;
+    const classes = useStyles(returnChipColor(state))();
+
+    return (
+        <Chip
+            classes={{
+                root: classes.root
+            }}
+            label={state}
+            size="small"
+        />
+    );
+}
+
+export default StyledChip;

--- a/rmf_panel/src/components/styles.tsx
+++ b/rmf_panel/src/components/styles.tsx
@@ -1,0 +1,107 @@
+import { makeStyles } from '@material-ui/core';
+
+export const useHeaderStyles = makeStyles({
+    centralise: {
+        paddingTop: '1rem',
+        paddingBottom: '1rem',
+        margin: "auto"
+    }
+});
+
+export const useFooterStyles = makeStyles({
+   footer: {
+       backgroundColor: "#FAFAFA",
+       paddingTop: "1em",
+       paddingBottom: "1em",
+       textAlign: "center"
+   }
+});
+
+export const usePanelContainerStyles = makeStyles(theme => ({
+   panels: {
+       paddingTop: "1em",
+       paddingBottom: "2em"
+   },
+    centered: {
+      padding: theme.spacing(2),
+      textAlign: 'center',
+      color: theme.palette.text.secondary,
+    }
+}));
+
+export const useContainerStyles = makeStyles({
+    container: {
+        paddingTop: "1em",
+        paddingBottom: "1em",
+        maxHeight: "75vh",
+        verticalAlign: "top",
+        overflow: "auto",
+        minHeight: 0
+    },
+    grid: {
+        overflow: "hidden",
+        flexDirection: "row",
+        verticalAlign: "top",
+    }
+});
+
+export const useFormStyles = makeStyles({
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    verticalAlign: "top",
+    paddingTop: "1em",
+    paddingBottom: "1em"
+  },
+  divForm: {
+    width: '100%',
+    marginTop: 0,
+    marginBottom: 0,
+    alignItems: 'center'
+  },
+  input: {
+    width: '100%',
+    marginTop: '1em',
+  },
+  label: {
+    width: '100%',
+  },
+  fileInput: {
+    width: '100%',
+    display: 'none'
+  },
+  selectButton: {
+    width: '50%'
+  },
+  button: {
+    width: '70%',
+  },
+  buttonContainer: {
+    marginTop: '0.7rem',
+    marginBottom: '0.7rem',
+    width: '100%',
+    alignItems: 'center'
+  },
+});
+
+export const useTaskCardStyles = makeStyles({
+  root: {
+    maxWidth: 240,
+    margin: "0.25em",
+    textAlign: 'center',
+    justifyContent: 'center'
+  },
+});
+
+export const useRobotCardStyles = makeStyles({
+  root: {
+    maxWidth: 240,
+    maxHeight: 280,
+    overflow: "auto",
+    margin: "0.5em"
+  },
+  text: {
+    textAlign: "center"
+  }
+});

--- a/rmf_panel/src/components/tasks/task-card.tsx
+++ b/rmf_panel/src/components/tasks/task-card.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import Progress from 'antd/lib/progress';
+import StyledChip from '../styled-components/styled-chip';
+import { useTaskCardStyles } from '../styles';
+import { cancelTask } from '../services';
+import { orange } from '@material-ui/core/colors';
+import { NotificationSnackbar, NotificationTypes } from '../fixed-components/notification-snackbar';
+
+interface TaskCardProps {
+    taskState: {
+        task_id: string,
+        description: string,
+        robot_name: string,
+        state: 	string,
+        task_type: string,
+        priority: number,
+        start_time: number,
+        end_time: number,
+        progress: string,
+    }
+}
+
+export const TaskCard = (props: TaskCardProps) : React.ReactElement => {
+  const { taskState } = props;
+  const [lastKnownProgress, setLastKnownProgress] = React.useState(0);
+  const [currentTaskStatus, setCurrentTaskStatus] = React.useState(taskState.state);
+  const [snackbarMessage, setSnackbarMessage] = React.useState('');
+  const [openSnackbar, setOpenSnackbar] = React.useState(false);
+  const [messageType, setMessageType] = React.useState(NotificationTypes.Success);
+  const classes = useTaskCardStyles();
+
+  const returnProgressBar = (type: string) => {
+    switch (type) {
+      case 'Cancelled':
+        return (<Progress type="dashboard" gapDegree={120} showInfo={false}/>);
+
+      case 'Delayed':
+        return (<Progress type="dashboard" strokeColor={orange[50]} gapDegree={120} percent={lastKnownProgress}/>);
+
+      case 'Failed':
+        return (<Progress type="dashboard" gapDegree={120} percent={lastKnownProgress} status="exception" />);
+
+      default:
+        return (<Progress type="dashboard" gapDegree={120} percent={lastKnownProgress} />);
+    }
+  }
+
+  React.useEffect(() => {
+    let progValue = parseInt(taskState.progress);
+    if(isNaN(parseInt(taskState.progress))) {
+      setCurrentTaskStatus('Delayed');
+    } else {
+      setCurrentTaskStatus(taskState.state);
+      setLastKnownProgress(progValue);
+    }
+  }, [taskState.progress, taskState.state]);
+
+  const showErrorSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Error);
+    setOpenSnackbar(true);
+  }
+
+  const showSuccessSnackbar = (message: string): void => {
+    setSnackbarMessage(message);
+    setMessageType(NotificationTypes.Success);
+    setOpenSnackbar(true);
+  }
+
+  const handleCancel = async (id: string) => {
+    let response = await cancelTask(id);
+    if (response["success"] === false) {
+      showErrorSnackbar(`Failed to cancel Task ID [${id}]`);
+    } else {
+      setCurrentTaskStatus('Cancelled');
+      showSuccessSnackbar(`Task ID [${id}] cancelled successfully`);
+    }
+  }
+
+  return (
+      <Card className={classes.root} variant="outlined" role="task-details">
+          <CardContent>
+            <Grid container>
+              <Grid item xs={12}>
+                {returnProgressBar(currentTaskStatus)}
+              </Grid>
+                <Grid item xs={6}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    Task ID
+                  </Typography>
+                </Grid>
+                <Grid item xs={6}><Typography>{taskState.task_id}</Typography></Grid>
+                <Grid item xs={6}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    Details
+                  </Typography>
+                </Grid>
+                <Grid item xs={6}><Typography>{taskState.description}</Typography></Grid>
+                <Grid item xs={6}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    Robot
+                  </Typography>
+                </Grid>
+                <Grid item xs={6}><Typography>{taskState.robot_name}</Typography></Grid>
+                <Grid item xs={6}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    Task Type
+                  </Typography>
+                </Grid>
+                <Grid item xs={6}><Typography>{taskState.task_type}</Typography></Grid>
+                <Grid item xs={6}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    Priority
+                  </Typography>
+                </Grid>
+                <Grid item xs={6}><Typography>{taskState.priority}</Typography></Grid>
+                <Grid item xs={6}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    Task State
+                  </Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <StyledChip state={taskState.state}/>
+                </Grid>
+                <Grid item xs={3}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    Start:
+                  </Typography>
+                </Grid>
+                <Grid item xs={3}><Typography>{taskState.start_time}</Typography></Grid>
+                <Grid item xs={3}>
+                  <Typography variant="subtitle2" align="left" color="textSecondary" gutterBottom>
+                    End:
+                  </Typography>
+                </Grid>
+                <Grid item xs={3}><Typography>{taskState.end_time}</Typography></Grid>
+                <Grid item xs={12}><Button variant="outlined" onClick={() => handleCancel(taskState.task_id)} disabled={ ['Cancelled', 'Completed', 'Failed'].indexOf(currentTaskStatus) != -1 }>Cancel Task</Button></Grid>
+            </Grid>
+          </CardContent>
+          {openSnackbar && <NotificationSnackbar type={messageType} message={snackbarMessage} closeSnackbarCallback={() => setOpenSnackbar(false)} />}
+      </Card>
+  );
+}

--- a/rmf_panel/src/components/tasks/tasks-container.tsx
+++ b/rmf_panel/src/components/tasks/tasks-container.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { TaskCard } from './task-card';
+import { useContainerStyles } from '../styles';
+import { getTasks } from "../services";
+import { socket } from '../socket';
+
+const TasksContainer = () : React.ReactElement => {
+    const classes = useContainerStyles();
+    const [taskStates, setTaskStates] = React.useState([]);
+
+    const refreshTaskData = async () => {
+        let updatedData = await getTasks();
+        if(updatedData != taskStates) {
+            setTaskStates(updatedData);
+        }
+    }
+
+    React.useEffect(() => {
+        let isSubscribed = true;
+        socket.on("task_status", taskData => {
+            if(isSubscribed) {
+                setTaskStates(taskData);
+            }
+        });
+        return () => {isSubscribed = false};
+    });
+
+    const allTasks = taskStates.map(taskState => {
+        return <Grid item><TaskCard taskState={taskState} /></Grid>
+    });
+
+    return (
+        <Box className={classes.container}>
+            <Typography variant="h5">Tasks</Typography>
+            <Button variant="outlined" onClick={refreshTaskData}>Refresh</Button>
+            <Grid container className={classes.grid}>
+                {allTasks}
+            </Grid>
+        </Box>
+    )
+}
+
+export default TasksContainer;

--- a/rmf_panel/src/index.tsx
+++ b/rmf_panel/src/index.tsx
@@ -1,0 +1,5 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import App from './app';
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/rmf_panel/tsconfig.json
+++ b/rmf_panel/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "Node",
+        "sourceMap": true,
+        "module": "commonjs",
+        "target": "es5",
+        "jsx": "react",
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "allowJs": true
+    },
+    "include": [
+        "./src/**/*.tsx",
+        "*.d.ts"
+    ],
+    "exclude": ["./node_modules"]
+}

--- a/rmf_panel/webpack.config.js
+++ b/rmf_panel/webpack.config.js
@@ -1,0 +1,55 @@
+const webpack = require('webpack');
+const resolve = require('path').resolve;
+
+const config = {
+    entry:  {
+        app: resolve(__dirname, 'src/index.tsx'),
+        //// NOTE: these are not necessary
+        // panels: resolve(__dirname, 'src/components/panels-container'),
+        // rosClock: resolve(__dirname, 'src/components/fixed-components/rostime-clock'),
+        // cleaningForm: resolve(__dirname, 'src/components/forms/cleaning-form'),
+        // deliveryForm: resolve(__dirname, 'src/components/forms/delivery-form'),
+        // loopRequestForm: resolve(__dirname, 'src/components/forms/loop-request-form'),
+        // scheduledTaskForm: resolve(__dirname, 'src/components/forms/scheduled-task-form'),
+        // taskContainer: resolve(__dirname, 'src/components/tasks/tasks-container'),
+        // robotContainer: resolve(__dirname, 'src/components/robots/robot-cards-container')
+    },
+    output: {
+      path: resolve(__dirname, './dist'),
+      filename: '[name].bundle.js',
+      chunkFilename: 'static/dist/[name].chunk.js'
+    },
+    plugins: [
+    new webpack.ids.HashedModuleIdsPlugin(), // so that file hashes don't change unexpectedly
+    ],
+    resolve: {
+        extensions: ['.js', '.jsx', '.css', '.tsx', '.ts']
+    },
+    module: {
+        rules: [
+            {
+                test: /\.(js|jsx)?/,
+                exclude: [/node_modules/, /\.(json)?/],
+                loader: 'babel-loader'
+            },
+            { 
+                test: /\.tsx?$/,
+                loader: 'ts-loader'
+            },
+            {
+                test: /\.json$/,
+                use: [
+                {
+                    loader: "file-loader",
+                    options: {
+                    esModule: false,
+                    },
+                },
+                ],
+                type: "javascript/auto",
+            },
+        ]
+    },
+};
+
+module.exports = config;


### PR DESCRIPTION
As mentioned on the README. We have move all front end component, specifically related to rmf-panel from `rmf_demos` to this new repo.

Access the link here: https://open-rmf.github.io/rmf-panel-js/

Similar as before, user just need to run `office.world`, then open this link hosted on github page.

*Future todo: configurable endpoint on GUI.*